### PR TITLE
fix: mtorrent搜索imdb时提供完整链接

### DIFF
--- a/app/modules/indexer/spider/mtorrent.py
+++ b/app/modules/indexer/spider/mtorrent.py
@@ -75,6 +75,9 @@ class MTorrentSpider:
             categories = self._tv_category
         else:
             categories = self._movie_category
+        # mtorrent搜索imdb需要输入完整imdb链接，参见 https://wiki.m-team.cc/zh-tw/imdbtosearch
+        if keyword.startswith("tt"):
+            keyword = f"https://www.imdb.com/title/{keyword}"
         return {
             "keyword": keyword,
             "categories": categories,


### PR DESCRIPTION
Fix: mtorrent搜索imdb时需要提供完整链接（例如https://www.imdb.com/title/tt3058674）

keyword为imdb条目时添加链接前缀

参考 https://wiki.m-team.cc/zh-tw/imdbtosearch
 
Fixes #4941